### PR TITLE
add answer- and hangup-buttons

### DIFF
--- a/custom_components/hikconnect/button.py
+++ b/custom_components/hikconnect/button.py
@@ -19,11 +19,46 @@ async def async_setup_entry(
 
     new_entities = []
     for device_info in coordinator.data:
+        new_entities.append(AnswerCallButton(api, device_info))
         new_entities.append(CancelCallButton(api, device_info))
+        new_entities.append(HangupCallButton(api, device_info))
 
     if new_entities:
         async_add_entities(new_entities, update_before_add=True)
 
+
+class AnswerCallButton(ButtonEntity):
+    """
+    Represents a answer call operation of an indoor station.
+    """
+
+    def __init__(self, api: HikConnect, device_info: dict):
+        super().__init__()
+        self._api = api
+        self._device_info = device_info
+
+    async def async_press(self) -> None:
+        await self._api.answer_call(self._device_info["serial"])
+
+    @property
+    def name(self):
+        return f"{self._device_info['name']} answer call"  # TODO translate?
+
+    @property
+    def unique_id(self):
+        return "-".join((DOMAIN, self._device_info["id"], "answer-call"))
+
+    @property
+    def device_info(self):
+        # https://developers.home-assistant.io/docs/device_registry_index/#device-properties
+        return {
+            "identifiers": {(DOMAIN, self._device_info["id"])},
+        }
+
+    @property
+    def icon(self):
+        return "mdi:phone"
+        
 
 class CancelCallButton(ButtonEntity):
     """
@@ -45,6 +80,39 @@ class CancelCallButton(ButtonEntity):
     @property
     def unique_id(self):
         return "-".join((DOMAIN, self._device_info["id"], "cancel-call"))
+
+    @property
+    def device_info(self):
+        # https://developers.home-assistant.io/docs/device_registry_index/#device-properties
+        return {
+            "identifiers": {(DOMAIN, self._device_info["id"])},
+        }
+
+    @property
+    def icon(self):
+        return "mdi:phone-hangup"
+
+
+class HangupCallButton(ButtonEntity):
+    """
+    Represents a hangup call operation of an indoor station.
+    """
+
+    def __init__(self, api: HikConnect, device_info: dict):
+        super().__init__()
+        self._api = api
+        self._device_info = device_info
+
+    async def async_press(self) -> None:
+        await self._api.hangup_call(self._device_info["serial"])
+
+    @property
+    def name(self):
+        return f"{self._device_info['name']} hangup call"  # TODO translate?
+
+    @property
+    def unique_id(self):
+        return "-".join((DOMAIN, self._device_info["id"], "hangup-call"))
 
     @property
     def device_info(self):

--- a/custom_components/hikconnect/manifest.json
+++ b/custom_components/hikconnect/manifest.json
@@ -17,7 +17,7 @@
 		"hikconnect"
 	],
 	"requirements": [
-		"hikconnect==1.1.0"
+		"hikconnect==1.2.0"
 	],
 	"version": "2.2.0"
 }


### PR DESCRIPTION
Requires https://github.com/tomasbedrich/hikconnect/pull/14 to be merged first.

This is an extension of #39 to also add the buttons for answering und hanging up calls.
This enables a "silent cancel" without the busy-sound (dut-dut-dut)...