### PR TITLE
Ignore hidden cameras

### DIFF
--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -78,6 +78,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             sw_version=device["version"],
         )
         for camera in device["cameras"]:
+            if not camera['is_shown']:
+                continue
             ha_camera_id = (DOMAIN, device["id"] + "-" + camera["id"])
             dr.async_get_or_create(
                 config_entry_id=entry.entry_id,


### PR DESCRIPTION
I have a lot of cameras in my aparatament block. Most of them are disabled (due to war in Ukraine).
Cameras are marked as `is_shown: 0`, but are still getting added as empty devices with no entities.
This PR skips the devices which are marked as hidden.