### PR TITLE
Fix #60/#62 and expose connectivity / IP / WiFi diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__
 .ipynb_checkpoints
 pip-wheel-metadata/
 .venv/
+
+# macOS
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ __pycache__
 .ipynb_checkpoints
 pip-wheel-metadata/
 .venv/
-
-# macOS
-.DS_Store

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -38,84 +38,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 # TODO add config_flow reauthenticate handler
                 raise ConfigEntryAuthFailed from e
 
-    async def async_fetch_pagelist_extras() -> dict:
-        """Fetch CONNECTION/STATUS/WIFI fields the hikconnect lib drops.
-
-        Returns serial -> dict with local_ip, wan_ip, is_online,
-        wifi_signal, update_available.
-        """
-        result: dict = {}
-        connections: dict = {}
-        statuses: dict = {}
-        wifis: dict = {}
-        limit, offset = 50, 0
-        while True:
-            url = (
-                f"{api.BASE_URL}/v3/userdevices/v1/devices/pagelist"
-                f"?groupId=-1&limit={limit}&offset={offset}"
-                "&filter=CONNECTION,STATUS,WIFI"
-            )
-            try:
-                async with api.client.get(url) as res:
-                    payload = await res.json()
-            except (aiohttp.ClientError, ValueError) as e:
-                _LOGGER.debug("Failed to fetch pagelist extras: %s", e)
-                return result
-            connections.update(payload.get("connectionInfos") or {})
-            statuses.update(payload.get("statusInfos") or {})
-            wifis.update(payload.get("wifiInfos") or {})
-            page = payload.get("page") or {}
-            if not page.get("hasNext"):
-                break
-            offset += limit
-        _LOGGER.debug(
-            "pagelist extras: connectionInfos serials=%s, statusInfos serials=%s, wifiInfos serials=%s",
-            list(connections), list(statuses), list(wifis),
-        )
-        for serial in {*connections, *statuses, *wifis}:
-            conn = connections.get(serial) or {}
-            wifi = wifis.get(serial) or {}
-            status = statuses.get(serial) or {}
-            _LOGGER.debug(
-                "pagelist extras for %s: CONNECTION=%s STATUS=%s WIFI=%s",
-                serial, conn, status, wifi,
-            )
-            local_ip = conn.get("localIp")
-            if not isinstance(local_ip, str) or not local_ip or local_ip == "0.0.0.0":
-                local_ip = wifi.get("address")
-            if not isinstance(local_ip, str) or local_ip == "0.0.0.0":
-                local_ip = None
-            wan_ip = conn.get("netIp")
-            if not isinstance(wan_ip, str) or not wan_ip or wan_ip == "0.0.0.0":
-                wan_ip = None
-            # globalStatus: 1=online, 2=sleep, 0/missing=offline.
-            status_code = status.get("globalStatus")
-            if status_code is None:
-                is_online = None
-            else:
-                is_online = status_code == 1
-            wifi_signal = wifi.get("signal")
-            if not isinstance(wifi_signal, int):
-                wifi_signal = None
-            upgrade_available = status.get("upgradeAvailable")
-            if upgrade_available is None:
-                update_available = None
-            else:
-                update_available = bool(upgrade_available)
-            # Cloud keeps stale IP/signal after device drops; clear them.
-            if not is_online:
-                local_ip = None
-                wan_ip = None
-                wifi_signal = None
-            result[serial] = {
-                "local_ip": local_ip,
-                "wan_ip": wan_ip,
-                "is_online": is_online,
-                "wifi_signal": wifi_signal,
-                "update_available": update_available,
-            }
-        return result
-
     async def async_update():
         try:
             await relogin_if_needed()
@@ -132,19 +54,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     _LOGGER.warning("Skipping device with malformed data: %s", e)
                     continue
                 devices.append(device)
-            extras = await async_fetch_pagelist_extras()
-            empty_extras = {
-                "local_ip": None,
-                "wan_ip": None,
-                "is_online": None,
-                "wifi_signal": None,
-                "update_available": None,
-            }
             for device_info in devices:
                 _LOGGER.info("Getting cameras for device: '%s'", device_info["serial"])
                 cameras = [c async for c in api.get_cameras(device_info["serial"])]
                 device_info.update({"cameras": cameras})
-                device_info.update(extras.get(device_info["serial"], empty_extras))
             return devices
         except (HikConnectError, aiohttp.ClientError) as e:
             raise UpdateFailed(e) from e

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -37,15 +37,80 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 # TODO add config_flow reauthenticate handler
                 raise ConfigEntryAuthFailed from e
 
+    async def async_fetch_pagelist_extras() -> dict:
+        """Fetch CONNECTION/STATUS info that the hikconnect lib does not expose.
+
+        The /devices/pagelist endpoint already returns these blocks per serial;
+        we issue an extra request because the underlying library only yields
+        a small subset of fields. Returns a mapping of serial -> dict with
+        keys: local_ip, wan_ip, is_online.
+        """
+        url = (
+            f"{api.BASE_URL}/v3/userdevices/v1/devices/pagelist"
+            "?groupId=-1&limit=50&offset=0&filter=CONNECTION,STATUS,WIFI"
+        )
+        result: dict = {}
+        try:
+            async with api.client.get(url) as res:
+                payload = await res.json()
+        except (aiohttp.ClientError, ValueError) as e:
+            _LOGGER.debug("Failed to fetch pagelist extras: %s", e)
+            return result
+        connections = payload.get("connectionInfos") or {}
+        statuses = payload.get("statusInfos") or {}
+        wifis = payload.get("wifiInfos") or {}
+        _LOGGER.debug(
+            "pagelist extras: connectionInfos serials=%s, statusInfos serials=%s, wifiInfos serials=%s",
+            list(connections), list(statuses), list(wifis),
+        )
+        for serial in {*connections, *statuses, *wifis}:
+            conn = connections.get(serial) or {}
+            wifi = wifis.get(serial) or {}
+            status = statuses.get(serial) or {}
+            _LOGGER.debug(
+                "pagelist extras for %s: CONNECTION=%s STATUS=%s WIFI=%s",
+                serial, conn, status, wifi,
+            )
+            local_ip = conn.get("localIp")
+            if not local_ip or local_ip == "0.0.0.0":
+                local_ip = wifi.get("address")
+            if local_ip == "0.0.0.0":
+                local_ip = None
+            wan_ip = conn.get("netIp") or None
+            if wan_ip == "0.0.0.0":
+                wan_ip = None
+            # Hik-Connect ``globalStatus`` codes (mirroring EZVIZ):
+            #   1 == online, 2 == sleeping, 0/missing == offline.
+            # Use ``None`` when the field is missing so the connectivity
+            # sensor reports "unavailable" instead of falsely flagging the
+            # device as offline.
+            status_code = status.get("globalStatus")
+            if status_code is None:
+                is_online = None
+            else:
+                is_online = status_code == 1
+            result[serial] = {
+                "local_ip": local_ip,
+                "wan_ip": wan_ip,
+                "is_online": is_online,
+            }
+        return result
+
     async def async_update():
         try:
             await relogin_if_needed()
             _LOGGER.info("Getting devices")
             devices = [device async for device in api.get_devices()]
+            extras = await async_fetch_pagelist_extras()
+            empty_extras = {"local_ip": None, "wan_ip": None, "is_online": None}
             for device_info in devices:
                 _LOGGER.info("Getting cameras for device: '%s'", device_info["serial"])
                 cameras = [c async for c in api.get_cameras(device_info["serial"])]
                 device_info.update({"cameras": cameras})
+                # If the extras endpoint failed or omitted this serial,
+                # surface ``None`` so the diagnostic sensors mark themselves
+                # unavailable instead of misreporting a connected device.
+                device_info.update(extras.get(device_info["serial"], empty_extras))
             return devices
         except (HikConnectError, aiohttp.ClientError) as e:
             raise UpdateFailed(e) from e
@@ -57,12 +122,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # and `api.is_refresh_login_needed()` => let's update it more often
     # than once per hour.
     # see: https://github.com/tomasbedrich/home-assistant-hikconnect/issues/27
+    # The same poll also refreshes the connectivity / local-IP / WAN-IP
+    # diagnostic sensors, so we keep the interval short enough that an
+    # offline device shows up within a few minutes.
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name=DOMAIN,
         update_method=async_update,
-        update_interval=timedelta(minutes=30),
+        update_interval=timedelta(minutes=5),
     )
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -89,10 +89,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 is_online = None
             else:
                 is_online = status_code == 1
+            wifi_signal = wifi.get("signal")
+            if not isinstance(wifi_signal, int):
+                wifi_signal = None
+            upgrade_available = status.get("upgradeAvailable")
+            if upgrade_available is None:
+                update_available = None
+            else:
+                update_available = bool(upgrade_available)
             result[serial] = {
                 "local_ip": local_ip,
                 "wan_ip": wan_ip,
                 "is_online": is_online,
+                "wifi_signal": wifi_signal,
+                "update_available": update_available,
             }
         return result
 
@@ -102,7 +112,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             _LOGGER.info("Getting devices")
             devices = [device async for device in api.get_devices()]
             extras = await async_fetch_pagelist_extras()
-            empty_extras = {"local_ip": None, "wan_ip": None, "is_online": None}
+            empty_extras = {
+                "local_ip": None,
+                "wan_ip": None,
+                "is_online": None,
+                "wifi_signal": None,
+                "update_available": None,
+            }
             for device_info in devices:
                 _LOGGER.info("Getting cameras for device: '%s'", device_info["serial"])
                 cameras = [c async for c in api.get_cameras(device_info["serial"])]

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -110,6 +110,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 update_available = None
             else:
                 update_available = bool(upgrade_available)
+            # When the device is not actively reporting to the cloud the
+            # IP and signal values are stale (the cloud keeps the last
+            # known ones around for hours). Drop them so the sensors go
+            # unavailable instead of showing a value that no longer holds.
+            if not is_online:
+                local_ip = None
+                wan_ip = None
+                wifi_signal = None
             result[serial] = {
                 "local_ip": local_ip,
                 "wan_ip": wan_ip,

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -46,20 +46,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         a small subset of fields. Returns a mapping of serial -> dict with
         keys: local_ip, wan_ip, is_online.
         """
-        url = (
-            f"{api.BASE_URL}/v3/userdevices/v1/devices/pagelist"
-            "?groupId=-1&limit=50&offset=0&filter=CONNECTION,STATUS,WIFI"
-        )
         result: dict = {}
-        try:
-            async with api.client.get(url) as res:
-                payload = await res.json()
-        except (aiohttp.ClientError, ValueError) as e:
-            _LOGGER.debug("Failed to fetch pagelist extras: %s", e)
-            return result
-        connections = payload.get("connectionInfos") or {}
-        statuses = payload.get("statusInfos") or {}
-        wifis = payload.get("wifiInfos") or {}
+        connections: dict = {}
+        statuses: dict = {}
+        wifis: dict = {}
+        limit, offset = 50, 0
+        # Mirror the lib's pagination so accounts with more than 50 devices
+        # still get extras for every page.
+        while True:
+            url = (
+                f"{api.BASE_URL}/v3/userdevices/v1/devices/pagelist"
+                f"?groupId=-1&limit={limit}&offset={offset}"
+                "&filter=CONNECTION,STATUS,WIFI"
+            )
+            try:
+                async with api.client.get(url) as res:
+                    payload = await res.json()
+            except (aiohttp.ClientError, ValueError) as e:
+                _LOGGER.debug("Failed to fetch pagelist extras: %s", e)
+                return result
+            connections.update(payload.get("connectionInfos") or {})
+            statuses.update(payload.get("statusInfos") or {})
+            wifis.update(payload.get("wifiInfos") or {})
+            page = payload.get("page") or {}
+            if not page.get("hasNext"):
+                break
+            offset += limit
         _LOGGER.debug(
             "pagelist extras: connectionInfos serials=%s, statusInfos serials=%s, wifiInfos serials=%s",
             list(connections), list(statuses), list(wifis),
@@ -73,12 +85,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 serial, conn, status, wifi,
             )
             local_ip = conn.get("localIp")
-            if not local_ip or local_ip == "0.0.0.0":
+            if not isinstance(local_ip, str) or not local_ip or local_ip == "0.0.0.0":
                 local_ip = wifi.get("address")
-            if local_ip == "0.0.0.0":
+            if not isinstance(local_ip, str) or local_ip == "0.0.0.0":
                 local_ip = None
-            wan_ip = conn.get("netIp") or None
-            if wan_ip == "0.0.0.0":
+            wan_ip = conn.get("netIp")
+            if not isinstance(wan_ip, str) or not wan_ip or wan_ip == "0.0.0.0":
                 wan_ip = None
             # Hik-Connect ``globalStatus`` codes (mirroring EZVIZ):
             #   1 == online, 2 == sleeping, 0/missing == offline.

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import timedelta
 
@@ -110,7 +111,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         try:
             await relogin_if_needed()
             _LOGGER.info("Getting devices")
-            devices = [device async for device in api.get_devices()]
+            # Skip devices with malformed payload instead of aborting
+            # the whole list - see issue #62.
+            devices = []
+            it = api.get_devices()
+            while True:
+                try:
+                    device = await it.__anext__()
+                except StopAsyncIteration:
+                    break
+                except json.JSONDecodeError as e:
+                    _LOGGER.warning("Skipping device with malformed data: %s", e)
+                    continue
+                devices.append(device)
             extras = await async_fetch_pagelist_extras()
             empty_extras = {
                 "local_ip": None,

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -67,8 +67,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await coordinator.async_config_entry_first_refresh()
 
     dr = device_registry.async_get(hass)
+    expected_identifiers: set[tuple[str, str]] = set()
     for device in coordinator.data:
         ha_device_id = (DOMAIN, device["id"])
+        expected_identifiers.add(ha_device_id)
         dr.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={ha_device_id},
@@ -78,15 +80,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             sw_version=device["version"],
         )
         for camera in device["cameras"]:
-            if not camera['is_shown']:
+            # Skip cameras that are hidden or have no controllable locks.
+            # Indoor units report many phantom "camera" channels with no
+            # entities attached; registering them creates orphan devices.
+            # see: https://github.com/tomasbedrich/home-assistant-hikconnect/issues/60
+            if not camera["is_shown"]:
+                continue
+            if not device["locks"].get(camera["channel_number"], 0):
                 continue
             ha_camera_id = (DOMAIN, device["id"] + "-" + camera["id"])
+            expected_identifiers.add(ha_camera_id)
             dr.async_get_or_create(
                 config_entry_id=entry.entry_id,
                 identifiers={ha_camera_id},
                 name=camera["name"],
                 manufacturer=MANUFACTURER,
                 via_device=ha_device_id,
+            )
+
+    # Clean up devices created by previous versions that no longer correspond
+    # to a real device or a camera with locks.
+    for ha_device in device_registry.async_entries_for_config_entry(
+        dr, entry.entry_id
+    ):
+        if not any(ident in expected_identifiers for ident in ha_device.identifiers):
+            dr.async_update_device(
+                ha_device.id, remove_config_entry_id=entry.entry_id
             )
 
     # TODO handle multiple instances of the same integration

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -154,9 +154,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 _LOGGER.info("Getting cameras for device: '%s'", device_info["serial"])
                 cameras = [c async for c in api.get_cameras(device_info["serial"])]
                 device_info.update({"cameras": cameras})
-                # If the extras endpoint failed or omitted this serial,
-                # surface ``None`` so the diagnostic sensors mark themselves
-                # unavailable instead of misreporting a connected device.
+                # Fall back to None values so missing fields read as unavailable.
                 device_info.update(extras.get(device_info["serial"], empty_extras))
             return devices
         except (HikConnectError, aiohttp.ClientError) as e:

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -39,12 +39,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 raise ConfigEntryAuthFailed from e
 
     async def async_fetch_pagelist_extras() -> dict:
-        """Fetch CONNECTION/STATUS info that the hikconnect lib does not expose.
+        """Fetch CONNECTION/STATUS/WIFI fields the hikconnect lib drops.
 
-        The /devices/pagelist endpoint already returns these blocks per serial;
-        we issue an extra request because the underlying library only yields
-        a small subset of fields. Returns a mapping of serial -> dict with
-        keys: local_ip, wan_ip, is_online.
+        Returns serial -> dict with local_ip, wan_ip, is_online,
+        wifi_signal, update_available.
         """
         result: dict = {}
         connections: dict = {}

--- a/custom_components/hikconnect/__init__.py
+++ b/custom_components/hikconnect/__init__.py
@@ -49,8 +49,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         statuses: dict = {}
         wifis: dict = {}
         limit, offset = 50, 0
-        # Mirror the lib's pagination so accounts with more than 50 devices
-        # still get extras for every page.
         while True:
             url = (
                 f"{api.BASE_URL}/v3/userdevices/v1/devices/pagelist"
@@ -90,11 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             wan_ip = conn.get("netIp")
             if not isinstance(wan_ip, str) or not wan_ip or wan_ip == "0.0.0.0":
                 wan_ip = None
-            # Hik-Connect ``globalStatus`` codes (mirroring EZVIZ):
-            #   1 == online, 2 == sleeping, 0/missing == offline.
-            # Use ``None`` when the field is missing so the connectivity
-            # sensor reports "unavailable" instead of falsely flagging the
-            # device as offline.
+            # globalStatus: 1=online, 2=sleep, 0/missing=offline.
             status_code = status.get("globalStatus")
             if status_code is None:
                 is_online = None
@@ -108,10 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 update_available = None
             else:
                 update_available = bool(upgrade_available)
-            # When the device is not actively reporting to the cloud the
-            # IP and signal values are stale (the cloud keeps the last
-            # known ones around for hours). Drop them so the sensors go
-            # unavailable instead of showing a value that no longer holds.
+            # Cloud keeps stale IP/signal after device drops; clear them.
             if not is_online:
                 local_ip = None
                 wan_ip = None
@@ -129,8 +120,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         try:
             await relogin_if_needed()
             _LOGGER.info("Getting devices")
-            # Skip devices with malformed payload instead of aborting
-            # the whole list - see issue #62.
+            # Skip devices with malformed payload - see #62.
             devices = []
             it = api.get_devices()
             while True:
@@ -154,7 +144,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 _LOGGER.info("Getting cameras for device: '%s'", device_info["serial"])
                 cameras = [c async for c in api.get_cameras(device_info["serial"])]
                 device_info.update({"cameras": cameras})
-                # Fall back to None values so missing fields read as unavailable.
                 device_info.update(extras.get(device_info["serial"], empty_extras))
             return devices
         except (HikConnectError, aiohttp.ClientError) as e:
@@ -167,9 +156,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # and `api.is_refresh_login_needed()` => let's update it more often
     # than once per hour.
     # see: https://github.com/tomasbedrich/home-assistant-hikconnect/issues/27
-    # The same poll also refreshes the connectivity / local-IP / WAN-IP
-    # diagnostic sensors, so we keep the interval short enough that an
-    # offline device shows up within a few minutes.
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
@@ -193,9 +179,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             sw_version=device["version"],
         )
         for camera in device["cameras"]:
-            # Skip cameras that are hidden or have no controllable locks.
-            # Indoor units report many phantom "camera" channels with no
-            # entities attached; registering them creates orphan devices.
             # see: https://github.com/tomasbedrich/home-assistant-hikconnect/issues/60
             if not camera["is_shown"]:
                 continue
@@ -211,8 +194,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 via_device=ha_device_id,
             )
 
-    # Clean up devices created by previous versions that no longer correspond
-    # to a real device or a camera with locks.
+    # Drop orphan devices created by previous versions.
     for ha_device in device_registry.async_entries_for_config_entry(
         dr, entry.entry_id
     ):

--- a/custom_components/hikconnect/binary_sensor.py
+++ b/custom_components/hikconnect/binary_sensor.py
@@ -1,0 +1,82 @@
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN]["coordinator"]
+
+    new_entities = [
+        ConnectivitySensor(coordinator, index)
+        for index, _ in enumerate(coordinator.data)
+    ]
+    if new_entities:
+        async_add_entities(new_entities)
+
+
+class ConnectivitySensor(CoordinatorEntity, BinarySensorEntity):
+    """
+    Reports whether the device is online and reachable to the Hik-Connect cloud.
+
+    Backed by the ``statusInfos[serial].globalStatus`` field of the
+    /devices/pagelist response. Hik-Connect reports ``1`` when the device
+    is online; ``0`` (offline) and ``2`` (sleeping) are treated as not
+    connected.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: DataUpdateCoordinator, device_index: int):
+        super().__init__(coordinator)
+        self._device_index = device_index
+
+    @property
+    def _device_info_data(self) -> dict:
+        return self.coordinator.data[self._device_index]
+
+    @property
+    def name(self):
+        return f"{self._device_info_data['name']} online"
+
+    @property
+    def unique_id(self):
+        return "-".join((DOMAIN, self._device_info_data["id"], "online"))
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self._device_info_data.get("is_online"))
+
+    @property
+    def available(self) -> bool:
+        # Mark unavailable when the cloud did not surface a status code
+        # (e.g. the extras request failed) so we don't falsely report
+        # "disconnected" while the device is actually fine.
+        return (
+            super().available
+            and self._device_info_data.get("is_online") is not None
+        )
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device_info_data["id"])},
+        }

--- a/custom_components/hikconnect/binary_sensor.py
+++ b/custom_components/hikconnect/binary_sensor.py
@@ -24,9 +24,9 @@ async def async_setup_entry(
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN]["coordinator"]
 
     new_entities: list[BinarySensorEntity] = []
-    for index, _ in enumerate(coordinator.data):
-        new_entities.append(ConnectivitySensor(coordinator, index))
-        new_entities.append(UpdateAvailableSensor(coordinator, index))
+    for device_info in coordinator.data:
+        new_entities.append(ConnectivitySensor(coordinator, device_info["id"]))
+        new_entities.append(UpdateAvailableSensor(coordinator, device_info["id"]))
     if new_entities:
         async_add_entities(new_entities)
 
@@ -41,21 +41,22 @@ class _CoordinatorBinarySensor(CoordinatorEntity, BinarySensorEntity):
     _suffix: str = ""
     _name_suffix: str = ""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_index: int):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
         super().__init__(coordinator)
-        self._device_index = device_index
+        self._device_id = device_id
+        self._attr_unique_id = "-".join((DOMAIN, device_id, self._suffix))
 
     @property
     def _device_info_data(self) -> dict:
-        return self.coordinator.data[self._device_index]
+        for device in self.coordinator.data or []:
+            if device.get("id") == self._device_id:
+                return device
+        return {}
 
     @property
     def name(self):
-        return f"{self._device_info_data['name']} {self._name_suffix}"
-
-    @property
-    def unique_id(self):
-        return "-".join((DOMAIN, self._device_info_data["id"], self._suffix))
+        name = self._device_info_data.get("name") or self._device_id
+        return f"{name} {self._name_suffix}"
 
     @property
     def is_on(self) -> bool:
@@ -73,7 +74,7 @@ class _CoordinatorBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self):
         return {
-            "identifiers": {(DOMAIN, self._device_info_data["id"])},
+            "identifiers": {(DOMAIN, self._device_id)},
         }
 
 

--- a/custom_components/hikconnect/binary_sensor.py
+++ b/custom_components/hikconnect/binary_sensor.py
@@ -64,8 +64,6 @@ class _CoordinatorBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def available(self) -> bool:
-        # Mark unavailable when the cloud did not surface this field so we
-        # do not flip the sensor to its "off" state while data is missing.
         return (
             super().available
             and self._device_info_data.get(self._field) is not None
@@ -79,14 +77,7 @@ class _CoordinatorBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
 
 class ConnectivitySensor(_CoordinatorBinarySensor):
-    """
-    Reports whether the device is online and reachable to the Hik-Connect cloud.
-
-    Backed by the ``statusInfos[serial].globalStatus`` field of the
-    /devices/pagelist response. Hik-Connect reports ``1`` when the device
-    is online; ``0`` (offline) and ``2`` (sleeping) are treated as not
-    connected.
-    """
+    """Online status from statusInfos.globalStatus (1=online)."""
 
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _field = "is_online"

--- a/custom_components/hikconnect/binary_sensor.py
+++ b/custom_components/hikconnect/binary_sensor.py
@@ -23,27 +23,23 @@ async def async_setup_entry(
 ) -> None:
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN]["coordinator"]
 
-    new_entities = [
-        ConnectivitySensor(coordinator, index)
-        for index, _ in enumerate(coordinator.data)
-    ]
+    new_entities: list[BinarySensorEntity] = []
+    for index, _ in enumerate(coordinator.data):
+        new_entities.append(ConnectivitySensor(coordinator, index))
+        new_entities.append(UpdateAvailableSensor(coordinator, index))
     if new_entities:
         async_add_entities(new_entities)
 
 
-class ConnectivitySensor(CoordinatorEntity, BinarySensorEntity):
-    """
-    Reports whether the device is online and reachable to the Hik-Connect cloud.
+class _CoordinatorBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Common boilerplate for Hik-Connect diagnostic binary sensors."""
 
-    Backed by the ``statusInfos[serial].globalStatus`` field of the
-    /devices/pagelist response. Hik-Connect reports ``1`` when the device
-    is online; ``0`` (offline) and ``2`` (sleeping) are treated as not
-    connected.
-    """
-
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
+
+    _field: str = ""
+    _suffix: str = ""
+    _name_suffix: str = ""
 
     def __init__(self, coordinator: DataUpdateCoordinator, device_index: int):
         super().__init__(coordinator)
@@ -55,24 +51,23 @@ class ConnectivitySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def name(self):
-        return f"{self._device_info_data['name']} online"
+        return f"{self._device_info_data['name']} {self._name_suffix}"
 
     @property
     def unique_id(self):
-        return "-".join((DOMAIN, self._device_info_data["id"], "online"))
+        return "-".join((DOMAIN, self._device_info_data["id"], self._suffix))
 
     @property
     def is_on(self) -> bool:
-        return bool(self._device_info_data.get("is_online"))
+        return bool(self._device_info_data.get(self._field))
 
     @property
     def available(self) -> bool:
-        # Mark unavailable when the cloud did not surface a status code
-        # (e.g. the extras request failed) so we don't falsely report
-        # "disconnected" while the device is actually fine.
+        # Mark unavailable when the cloud did not surface this field so we
+        # do not flip the sensor to its "off" state while data is missing.
         return (
             super().available
-            and self._device_info_data.get("is_online") is not None
+            and self._device_info_data.get(self._field) is not None
         )
 
     @property
@@ -80,3 +75,28 @@ class ConnectivitySensor(CoordinatorEntity, BinarySensorEntity):
         return {
             "identifiers": {(DOMAIN, self._device_info_data["id"])},
         }
+
+
+class ConnectivitySensor(_CoordinatorBinarySensor):
+    """
+    Reports whether the device is online and reachable to the Hik-Connect cloud.
+
+    Backed by the ``statusInfos[serial].globalStatus`` field of the
+    /devices/pagelist response. Hik-Connect reports ``1`` when the device
+    is online; ``0`` (offline) and ``2`` (sleeping) are treated as not
+    connected.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _field = "is_online"
+    _suffix = "online"
+    _name_suffix = "online"
+
+
+class UpdateAvailableSensor(_CoordinatorBinarySensor):
+    """Reports whether a firmware update is available for the device."""
+
+    _attr_device_class = BinarySensorDeviceClass.UPDATE
+    _field = "update_available"
+    _suffix = "update-available"
+    _name_suffix = "update available"

--- a/custom_components/hikconnect/const.py
+++ b/custom_components/hikconnect/const.py
@@ -1,3 +1,3 @@
 DOMAIN = "hikconnect"
 MANUFACTURER = "Hikvision"
-PLATFORMS = ["lock", "sensor", "button"]
+PLATFORMS = ["lock", "sensor", "button", "binary_sensor"]

--- a/custom_components/hikconnect/manifest.json
+++ b/custom_components/hikconnect/manifest.json
@@ -17,7 +17,7 @@
 		"hikconnect"
 	],
 	"requirements": [
-		"hikconnect==1.2.1"
+		"hikconnect==2.0.0"
 	],
 	"version": "2.4.0"
 }

--- a/custom_components/hikconnect/sensor.py
+++ b/custom_components/hikconnect/sensor.py
@@ -8,7 +8,12 @@ from hikconnect.api import HikConnect
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,8 +45,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     _patch_hikconnect_logger()
 
     new_entities = []
-    for device_info in coordinator.data:
+    for index, device_info in enumerate(coordinator.data):
         new_entities.append(CallStatusSensor(api, device_info))
+        new_entities.append(LocalIpSensor(coordinator, index))
+        new_entities.append(WanIpSensor(coordinator, index))
 
     if new_entities:
         async_add_entities(new_entities, update_before_add=True)
@@ -100,3 +107,71 @@ class CallStatusSensor(SensorEntity):
             return "mdi:phone-in-talk"
         else:
             return "mdi:phone-alert"
+
+
+class _DeviceFieldSensor(CoordinatorEntity, SensorEntity):
+    """Base sensor backed by a single coordinator device field."""
+
+    _field: str = ""
+    _suffix: str = ""
+    _icon: str = ""
+    _name_suffix: str = ""
+
+    # Diagnostic sensors are off by default - the cloud values are useful
+    # for troubleshooting but rarely needed in dashboards.
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: DataUpdateCoordinator, device_index: int):
+        super().__init__(coordinator)
+        self._device_index = device_index
+
+    @property
+    def _device_info_data(self) -> dict:
+        return self.coordinator.data[self._device_index]
+
+    @property
+    def name(self):
+        return f"{self._device_info_data['name']} {self._name_suffix}"
+
+    @property
+    def unique_id(self):
+        return "-".join((DOMAIN, self._device_info_data["id"], self._suffix))
+
+    @property
+    def native_value(self):
+        return self._device_info_data.get(self._field)
+
+    @property
+    def available(self) -> bool:
+        # Mark unavailable when the cloud did not surface this field
+        # (e.g. the extras request failed or the device omitted it).
+        return super().available and self.native_value is not None
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device_info_data["id"])},
+        }
+
+    @property
+    def icon(self):
+        return self._icon
+
+
+class LocalIpSensor(_DeviceFieldSensor):
+    """LAN IP address reported by Hik-Connect cloud."""
+
+    _field = "local_ip"
+    _suffix = "local-ip"
+    _icon = "mdi:ip-network"
+    _name_suffix = "local IP"
+
+
+class WanIpSensor(_DeviceFieldSensor):
+    """Public/WAN IP address reported by Hik-Connect cloud."""
+
+    _field = "wan_ip"
+    _suffix = "wan-ip"
+    _icon = "mdi:wan"
+    _name_suffix = "WAN IP"

--- a/custom_components/hikconnect/sensor.py
+++ b/custom_components/hikconnect/sensor.py
@@ -5,8 +5,12 @@ from datetime import timedelta
 
 import aiohttp
 from hikconnect.api import HikConnect
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -49,6 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         new_entities.append(CallStatusSensor(api, device_info))
         new_entities.append(LocalIpSensor(coordinator, index))
         new_entities.append(WanIpSensor(coordinator, index))
+        new_entities.append(WifiSignalSensor(coordinator, index))
 
     if new_entities:
         async_add_entities(new_entities, update_before_add=True)
@@ -175,3 +180,15 @@ class WanIpSensor(_DeviceFieldSensor):
     _suffix = "wan-ip"
     _icon = "mdi:wan"
     _name_suffix = "WAN IP"
+
+
+class WifiSignalSensor(_DeviceFieldSensor):
+    """WiFi signal strength reported by the device (0-100)."""
+
+    _field = "wifi_signal"
+    _suffix = "wifi-signal"
+    _icon = "mdi:wifi-strength-3"
+    _name_suffix = "WiFi signal"
+
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT

--- a/custom_components/hikconnect/sensor.py
+++ b/custom_components/hikconnect/sensor.py
@@ -49,11 +49,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     _patch_hikconnect_logger()
 
     new_entities = []
-    for index, device_info in enumerate(coordinator.data):
+    for device_info in coordinator.data:
         new_entities.append(CallStatusSensor(api, device_info))
-        new_entities.append(LocalIpSensor(coordinator, index))
-        new_entities.append(WanIpSensor(coordinator, index))
-        new_entities.append(WifiSignalSensor(coordinator, index))
+        new_entities.append(LocalIpSensor(coordinator, device_info["id"]))
+        new_entities.append(WanIpSensor(coordinator, device_info["id"]))
+        new_entities.append(WifiSignalSensor(coordinator, device_info["id"]))
 
     if new_entities:
         async_add_entities(new_entities, update_before_add=True)
@@ -127,21 +127,22 @@ class _DeviceFieldSensor(CoordinatorEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_index: int):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
         super().__init__(coordinator)
-        self._device_index = device_index
+        self._device_id = device_id
+        self._attr_unique_id = "-".join((DOMAIN, device_id, self._suffix))
 
     @property
     def _device_info_data(self) -> dict:
-        return self.coordinator.data[self._device_index]
+        for device in self.coordinator.data or []:
+            if device.get("id") == self._device_id:
+                return device
+        return {}
 
     @property
     def name(self):
-        return f"{self._device_info_data['name']} {self._name_suffix}"
-
-    @property
-    def unique_id(self):
-        return "-".join((DOMAIN, self._device_info_data["id"], self._suffix))
+        name = self._device_info_data.get("name") or self._device_id
+        return f"{name} {self._name_suffix}"
 
     @property
     def native_value(self):
@@ -156,7 +157,7 @@ class _DeviceFieldSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self):
         return {
-            "identifiers": {(DOMAIN, self._device_info_data["id"])},
+            "identifiers": {(DOMAIN, self._device_id)},
         }
 
     @property

--- a/custom_components/hikconnect/sensor.py
+++ b/custom_components/hikconnect/sensor.py
@@ -122,8 +122,7 @@ class _DeviceFieldSensor(CoordinatorEntity, SensorEntity):
     _icon: str = ""
     _name_suffix: str = ""
 
-    # Diagnostic sensors are off by default - the cloud values are useful
-    # for troubleshooting but rarely needed in dashboards.
+    # Diagnostic, off by default.
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
 
@@ -150,8 +149,6 @@ class _DeviceFieldSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        # Mark unavailable when the cloud did not surface this field
-        # (e.g. the extras request failed or the device omitted it).
         return super().available and self.native_value is not None
 
     @property


### PR DESCRIPTION
## Summary

- **Closes #60** — stop registering phantom camera-channel devices (DS-KH63xx indoor units returned ~49 empty entries per device).
- **Closes #62** — skip devices with malformed `lockNum` instead of aborting setup.
- **May help #54** — same filter (no locks → no HA device) prunes camera-channel pollution under intercom devices. NVR / standalone-camera filtering is **not** included.
- New diagnostic entities: local IP, WAN IP, WiFi signal, online, update available — all `EntityCategory.DIAGNOSTIC`, **disabled by default**, fall back to *unavailable* when the cloud omits the field. IP / signal values are also dropped while the device is offline so they never show stale data.
- Coordinator interval 30 min → 5 min so the connectivity sensor reflects state changes within minutes.

## Why the diagnostic entities

My DS-KH6320 unit periodically loses DNS and silently drops off Hik-Connect even though the rest of the LAN is fine. Surfacing the cloud's `localIp`, `netIp`, WiFi signal and `globalStatus` lets me automate a notification when it goes offline, instead of finding out days later when somebody tries to ring the door.

## Screenshot
<img width="336" height="386" alt="NewSensors" src="https://github.com/user-attachments/assets/21f88832-d032-4808-94c8-b06cbf9bda28" />

## Implementation notes

- The five new fields (`local_ip`, `wan_ip`, `is_online`, `wifi_signal`, `update_available`) are now parsed directly inside `get_devices()` in the hikconnect library from data already present in the pagelist response — see [tomasbedrich/hikconnect#33](https://github.com/tomasbedrich/hikconnect/pull/33). No extra API call is made.
- This PR previously contained a second pagelist call (`async_fetch_pagelist_extras`) as a workaround. That has been removed in response to the maintainer's review; the extraction logic now lives entirely in the library where it belongs.
- `manifest.json` will be bumped to the new library version once #33 merges and a release is cut.
- No new dependencies. Tested on DS-KH6320-WTE1 + DS-KV8113. 49 phantom devices cleaned up on first reload; new entities populate (`192.168.1.29`, online=on, signal=100%, no firmware update).