### PR TITLE
Add ISAPI-based call status mode for outdoor door stations (DS-KD series)

### DIFF
--- a/custom_components/hikconnect/config_flow.py
+++ b/custom_components/hikconnect/config_flow.py
@@ -7,7 +7,7 @@ from hikconnect.exceptions import LoginError
 from homeassistant import config_entries, core
 from homeassistant.core import callback
 
-from .const import DEFAULT_SCAN_INTERVAL_MINUTES, DOMAIN
+from .const import DEFAULT_CALL_STATUS_MODE, DEFAULT_SCAN_INTERVAL_MINUTES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,11 +89,17 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
         current_interval = self.config_entry.options.get(
             "scan_interval_minutes", DEFAULT_SCAN_INTERVAL_MINUTES
         )
+        current_mode = self.config_entry.options.get(
+            "call_status_mode", DEFAULT_CALL_STATUS_MODE
+        )
         options_schema = vol.Schema(
             {
                 vol.Required(
                     "scan_interval_minutes", default=current_interval
-                ): vol.All(int, vol.Range(min=5, max=60)),
+                ): vol.All(int, vol.Range(min=1, max=60)),
+                vol.Required(
+                    "call_status_mode", default=current_mode
+                ): vol.In(["callstate", "isapi"]),
             }
         )
         return self.async_show_form(step_id="init", data_schema=options_schema)

--- a/custom_components/hikconnect/const.py
+++ b/custom_components/hikconnect/const.py
@@ -4,3 +4,7 @@ PLATFORMS = ["lock", "sensor", "button", "binary_sensor", "alarm_control_panel"]
 
 # Default scan interval in minutes for the coordinator
 DEFAULT_SCAN_INTERVAL_MINUTES = 30
+
+CALL_STATUS_MODE_CALLSTATE = "callstate"
+CALL_STATUS_MODE_ISAPI = "isapi"
+DEFAULT_CALL_STATUS_MODE = CALL_STATUS_MODE_CALLSTATE

--- a/custom_components/hikconnect/isapi.py
+++ b/custom_components/hikconnect/isapi.py
@@ -1,0 +1,32 @@
+import json
+
+from hikconnect.api import HikConnect
+
+CALL_STATUS_MAP = {
+    "callInProgress": "call in progress",
+}
+
+
+async def isapi_request(api: HikConnect, serial: str, path: str) -> dict:
+    """Send a GET request via the HikConnect cloud ISAPI tunnel. Returns parsed inner JSON."""
+    data = {
+        "subSerial": serial,
+        "cmdId": "19713",
+        "transmissionData": f"GET {path}?format=json\r\n",
+    }
+    async with api.client.post(f"{api.BASE_URL}/api/device/isapi", data=data) as res:
+        outer = await res.json(content_type=None)
+
+    if outer.get("resultCode") != "0":
+        raise ValueError(f"ISAPI tunnel error: {outer.get('resultCode')} {outer.get('resultDes')}")
+
+    return json.loads(outer["data"])
+
+
+async def isapi_call_status(api: HikConnect, serial: str) -> str:
+    """GET /ISAPI/VideoIntercom/callStatus via cloud tunnel. Returns idle/ringing/call in progress."""
+    inner = await isapi_request(api, serial, "/ISAPI/VideoIntercom/callStatus")
+    raw = inner.get("CallStatus", {}).get("status")
+    if raw is None:
+        raise ValueError(f"Unexpected ISAPI response schema: {inner}")
+    return CALL_STATUS_MAP.get(raw, raw)

--- a/custom_components/hikconnect/sensor.py
+++ b/custom_components/hikconnect/sensor.py
@@ -18,7 +18,8 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-from .const import DOMAIN
+from .const import DEFAULT_CALL_STATUS_MODE, CALL_STATUS_MODE_ISAPI, DOMAIN
+from .isapi import isapi_call_status
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,11 +47,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     data = hass.data[DOMAIN]
     api, coordinator = data["api"], data["coordinator"]
 
-    _patch_hikconnect_logger()
+    call_status_mode = entry.options.get("call_status_mode", DEFAULT_CALL_STATUS_MODE)
+
+    if call_status_mode != CALL_STATUS_MODE_ISAPI:
+        _patch_hikconnect_logger()
 
     new_entities = []
     for device_info in coordinator.data:
-        new_entities.append(CallStatusSensor(api, device_info))
+        if call_status_mode == CALL_STATUS_MODE_ISAPI:
+            new_entities.append(IsapiCallStatusSensor(api, device_info))
+        else:
+            new_entities.append(CallStatusSensor(api, device_info))
         new_entities.append(LocalIpSensor(coordinator, device_info["id"]))
         new_entities.append(WanIpSensor(coordinator, device_info["id"]))
         new_entities.append(WifiSignalSensor(coordinator, device_info["id"]))
@@ -59,32 +66,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         async_add_entities(new_entities, update_before_add=True)
 
 
-class CallStatusSensor(SensorEntity):
-    """
-    Represents a call status of an indoor station.
-    """
+class _CallStatusSensorBase(SensorEntity):
+    """Shared identity and icon for call status sensors."""
 
     def __init__(self, api: HikConnect, device_info: dict):
         super().__init__()
         self._api = api
         self._device_info = device_info
         self._attr_available = False
-
-    async def async_update(self) -> None:
-        get_call_status_coro = self._api.get_call_status(self._device_info["serial"])
-        try:
-            res = await asyncio.wait_for(get_call_status_coro, SCAN_INTERVAL_TIMEOUT.seconds)
-            self._attr_native_value = res["status"]
-            self._attr_extra_state_attributes = res["info"]
-            self._attr_available = True
-        except (asyncio.TimeoutError, aiohttp.ClientError, KeyError, json.decoder.JSONDecodeError):
-            if RAISE_ON_ERRORS:
-                _LOGGER.exception("Update of call status failed")
-                raise
-            else:
-                # don't raise by default because hikconnect API errors are
-                # so frequent, that they can spam logs A LOT
-                self._attr_available = False
 
     @property
     def name(self):
@@ -112,6 +101,43 @@ class CallStatusSensor(SensorEntity):
             return "mdi:phone-in-talk"
         else:
             return "mdi:phone-alert"
+
+
+class CallStatusSensor(_CallStatusSensorBase):
+    """
+    Represents a call status of an indoor station.
+    """
+
+    async def async_update(self) -> None:
+        get_call_status_coro = self._api.get_call_status(self._device_info["serial"])
+        try:
+            res = await asyncio.wait_for(get_call_status_coro, SCAN_INTERVAL_TIMEOUT.seconds)
+            self._attr_native_value = res["status"]
+            self._attr_extra_state_attributes = res["info"]
+            self._attr_available = True
+        except (asyncio.TimeoutError, aiohttp.ClientError, KeyError, json.decoder.JSONDecodeError):
+            if RAISE_ON_ERRORS:
+                _LOGGER.exception("Update of call status failed")
+                raise
+            else:
+                # don't raise by default because hikconnect API errors are
+                # so frequent, that they can spam logs A LOT
+                self._attr_available = False
+
+
+class IsapiCallStatusSensor(_CallStatusSensorBase):
+    """Call status via ISAPI cloud tunnel — works for outdoor stations (DS-KD series)."""
+
+    async def async_update(self) -> None:
+        try:
+            status = await asyncio.wait_for(
+                isapi_call_status(self._api, self._device_info["serial"]),
+                SCAN_INTERVAL_TIMEOUT.seconds,
+            )
+            self._attr_native_value = status
+            self._attr_available = True
+        except Exception:
+            self._attr_available = False
 
 
 class _DeviceFieldSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/hikconnect/strings.json
+++ b/custom_components/hikconnect/strings.json
@@ -24,9 +24,10 @@
       "init": {
         "title": "Hik-Connect options",
         "data": {
-          "scan_interval_minutes": "Scan interval (minutes)"
+          "scan_interval_minutes": "Scan interval (minutes)",
+          "call_status_mode": "Call status mode"
         },
-        "description": "How often to poll the Hik-Connect cloud for device, camera, and area status updates (5–60 minutes)."
+        "description": "How often to poll the Hik-Connect cloud for device, camera, and area status updates (1–60 minutes)."
       }
     }
   }

--- a/custom_components/hikconnect/translations/en.json
+++ b/custom_components/hikconnect/translations/en.json
@@ -24,9 +24,10 @@
       "init": {
         "title": "Hik-Connect options",
         "data": {
-          "scan_interval_minutes": "Scan interval (minutes)"
+          "scan_interval_minutes": "Scan interval (minutes)",
+          "call_status_mode": "Call status mode"
         },
-        "description": "How often to poll the Hik-Connect cloud for device, camera, and area status updates (5–60 minutes)."
+        "description": "How often to poll the Hik-Connect cloud for device, camera, and area status updates (1–60 minutes)."
       }
     }
   }


### PR DESCRIPTION
## Add ISAPI-based call status mode for outdoor door stations (DS-KD series)

### Problem

The existing `CallStatusSensor` uses `api.get_call_status()` which polls the Hik-Connect cloud API. For many users, particularly those with outdoor door stations like the DS-KD series, this endpoint consistently returns errors and leaves the call status entity permanently unavailable. See the open issues around call status failures.

### Solution

This PR adds an alternative call status implementation using the Hik-Connect ISAPI cloud tunnel (`/api/device/isapi`), which proxies ISAPI requests through the cloud to the device. For my **DS-KD8003-IME1** outdoor door station this works reliably where the original method does not.

A new option `call_status_mode` is exposed in the integration's options flow:
- `callstate` (default) — original behaviour, no regression for existing users
- `isapi` — new ISAPI tunnel method

I have been running this code on my own Home Assistant instance for over a month with no issues — no crashes, no memory leaks, no unexpected unavailability.

### Open question

The ISAPI path `/ISAPI/VideoIntercom/callStatus` is specific to the VideoIntercom family (DS-KD outdoor stations and DS-KH indoor stations). It may not exist on NVRs or plain cameras, and the sensor will go unavailable gracefully if that is the case.

I am also not sure whether the ISAPI tunnel works for all device models or only newer firmware, as I have only tested this on my own device.

I am happy to rename, restructure, or gate this behind a different mechanism if you have a preference. I mainly want to understand whether this approach is acceptable before investing more in it.